### PR TITLE
fix SER_END_DECL in dev.h

### DIFF
--- a/include/public/sercomm/dev.h
+++ b/include/public/sercomm/dev.h
@@ -137,6 +137,6 @@ SER_EXPORT void ser_dev_monitor_stop(ser_dev_mon_t *mon);
 
 /** @} */
 
-SER_BEGIN_DECL
+SER_END_DECL
 
 #endif


### PR DESCRIPTION
dev.h had the `SER_BEGIN_DECL` macro at the end of the file instead of `SER_END_DECL`, resulting in an error when included in C++